### PR TITLE
Fix typo in TelevisionTest comment

### DIFF
--- a/koans/about_proxy_object_project.rb
+++ b/koans/about_proxy_object_project.rb
@@ -128,7 +128,7 @@ class Television
   end
 end
 
-# Tests for the Television class.  All of theses tests should pass.
+# Tests for the Television class.  All of these tests should pass.
 class TelevisionTest < Neo::Koan
   def test_it_turns_on
     tv = Television.new


### PR DESCRIPTION
## Summary
- fix a small typo in TelevisionTest comment in about_proxy_object_project

## Testing
- `rake` *(fails: undefined method `exists?` for File:Class)*